### PR TITLE
fix: handle type name #0 being used as an argument type

### DIFF
--- a/runtime/src/client/linkTypeMap.ts
+++ b/runtime/src/client/linkTypeMap.ts
@@ -49,7 +49,7 @@ export function linkTypeMap(typeMap: CompressedTypeMap<number>): LinkedTypeMap {
                       }
                       // if argTypeString == argTypeName, argTypeString is missing, need to read it
                       const [argTypeName, argTypeString] = args[k] ?? [];
-                      if (!argTypeName) {
+                      if (!argTypeName && argTypeName !== 0) {
                         return {};
                       }
                       return {


### PR DESCRIPTION
This fix caters for circumstances where the argTypeName === 0.

Currently if a type or scalar is assigned to identifier 0 in the generated types.cjs.js file, it will be present and available in the generated types, but at runtime when attempting to use any mutation with an argument of this type, you will get an error:

```Error: no typing defined for argument `argumentFieldName` in path `mutationType`.```

This is because during generation of the runtime linked type map, the check for a missing argTypeName does not take into account the possibility of an argTypeName of 0 being used as a mutation argument. This is commonly the case in relation to the ID scalar - generally being the first scalar and therefore being assigned the argTypeName of 0.